### PR TITLE
Refactor: Remove extraneous icons from sidebar

### DIFF
--- a/src/components/MobileTopbar.tsx
+++ b/src/components/MobileTopbar.tsx
@@ -1,7 +1,6 @@
-
 import React, { useState } from 'react';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
-import { Menu, X, ArrowDownUp, LayoutDashboard, User, Github, ExternalLink, BookOpen, Link as LinkIcon } from 'lucide-react';
+import { Menu, X, ArrowDownUp, LayoutDashboard, User, Github, Link as LinkIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import Button from './Button';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
@@ -166,12 +165,6 @@ const MobileTopbar = () => {
                   </a>
                   <a href="#" className="text-white hover:text-[#AF9EF9] p-2 flex items-center justify-center">
                     <Github size={24} />
-                  </a>
-                  <a href="#" className="text-white hover:text-[#AF9EF9] p-2 flex items-center justify-center">
-                    <ExternalLink size={24} />
-                  </a>
-                  <a href="#" className="text-white hover:text-[#AF9EF9] p-2 flex items-center justify-center">
-                    <BookOpen size={24} />
                   </a>
                 </div>
               </div>

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -1,7 +1,6 @@
-
 import React from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { ArrowDownUp, LayoutDashboard, Link as LinkIcon, User, Github, ExternalLink, BookOpen } from 'lucide-react';
+import { ArrowDownUp, LayoutDashboard, Link as LinkIcon, User, Github } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const SidebarNav = () => {
@@ -132,12 +131,6 @@ const SidebarNav = () => {
         </a>
         <a href="#" className="text-white hover:text-[#AF9EF9] ml-[8px]">
           <Github size={20} />
-        </a>
-        <a href="#" className="text-white hover:text-[#AF9EF9] ml-[8px]">
-          <ExternalLink size={20} />
-        </a>
-        <a href="#" className="text-white hover:text-[#AF9EF9] ml-[8px]">
-          <BookOpen size={20} />
         </a>
       </div>
     </aside>


### PR DESCRIPTION
Removes all icons from the sidebar navigation except for the "X" (close) and GitHub icons, as requested.